### PR TITLE
Cryogenic Chamber Recipe Change

### DIFF
--- a/src/main/resources/assets/galacticraftplanets/recipes/mars_machine_4.json
+++ b/src/main/resources/assets/galacticraftplanets/recipes/mars_machine_4.json
@@ -20,7 +20,7 @@
     },
     "Z": {
       "item": "minecraft:bed",
-      "data": 0
+      "data": 32767
     }
   }
 }


### PR DESCRIPTION
Changes the Cryogenic Chamber's recipe by allowing for all colors of bed to be used, instead of just the white bed. This is something I'm sure is an oversight from other versions of Galacticraft 4 (1.8 - 1.11) since 1.12 introduced the multiple colors of bed.