### PR TITLE
Streamline description key to LSHIFT

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemBlockDesc.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemBlockDesc.java
@@ -59,7 +59,7 @@ public class ItemBlockDesc extends ItemBlockGC
     {
         if (this.getBlock() instanceof IShiftDescription && ((IShiftDescription) this.getBlock()).showDescription(stack.getItemDamage()))
         {
-            if (Keyboard.isKeyDown(FMLClientHandler.instance().getClient().gameSettings.keyBindSneak.getKeyCode()))
+            if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT))
             {
                 info.addAll(FMLClientHandler.instance().getClient().fontRenderer.listFormattedStringToWidth(((IShiftDescription) this.getBlock()).getShiftDescription(stack.getItemDamage()), 150));
             } else
@@ -87,7 +87,7 @@ public class ItemBlockDesc extends ItemBlockGC
                         }
                     }
                 }
-                info.add(GCCoreUtil.translateWithFormat("item_desc.shift.name", GameSettings.getKeyDisplayString(FMLClientHandler.instance().getClient().gameSettings.keyBindSneak.getKeyCode())));
+                info.add(GCCoreUtil.translateWithFormat("item_desc.shift.name", GameSettings.getKeyDisplayString(Keyboard.KEY_LSHIFT)));
             }
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemDesc.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemDesc.java
@@ -22,12 +22,12 @@ public abstract class ItemDesc extends Item implements IShiftDescription
     {
         if (this.showDescription(stack.getItemDamage()))
         {
-            if (Keyboard.isKeyDown(FMLClientHandler.instance().getClient().gameSettings.keyBindSneak.getKeyCode()))
+            if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT))
             {
                 info.addAll(FMLClientHandler.instance().getClient().fontRenderer.listFormattedStringToWidth(this.getShiftDescription(stack.getItemDamage()), 150));
             } else
             {
-                info.add(GCCoreUtil.translateWithFormat("item_desc.shift.name", GameSettings.getKeyDisplayString(FMLClientHandler.instance().getClient().gameSettings.keyBindSneak.getKeyCode())));
+                info.add(GCCoreUtil.translateWithFormat("item_desc.shift.name", GameSettings.getKeyDisplayString(Keyboard.KEY_LSHIFT)));
             }
         }
     }

--- a/src/main/java/micdoodle8/mods/galacticraft/planets/venus/items/ItemVolcanicPickaxe.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/venus/items/ItemVolcanicPickaxe.java
@@ -53,7 +53,7 @@ public class ItemVolcanicPickaxe extends ItemPickaxe implements ISortableItem, I
                 info.addAll(FMLClientHandler.instance().getClient().fontRenderer.listFormattedStringToWidth(this.getShiftDescription(stack.getItemDamage()), 150));
             } else
             {
-                info.add(GCCoreUtil.translateWithFormat("item_desc.shift.name", GameSettings.getKeyDisplayString(FMLClientHandler.instance().getClient().gameSettings.keyBindSneak.getKeyCode())));
+                info.add(GCCoreUtil.translateWithFormat("item_desc.shift.name", GameSettings.getKeyDisplayString(Keyboard.KEY_LSHIFT)));
             }
         }
     }


### PR DESCRIPTION
When a player sets their vanilla sneak key to a special key like additional mouse buttons (MOUSE4/MOUSE5), it exceeds the boundaries of default LWJGL keycodes, causing the game to crash when accessing blocks and items with tooltips and at startup: https://mclo.gs/l03Ssia

A simple solution to this rather gamebreaking bug is to just hardcode LSHIFT as a designated description key since it doesn‘t need to be tied to sneaking as such.