### PR TITLE
Various cross-mod energy compatibility fixes

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/energy/EnergyUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/energy/EnergyUtil.java
@@ -119,7 +119,7 @@ public class EnergyUtil
                 continue;
             }
 
-            if (isMekLoaded && (tileEntity instanceof IStrictEnergyAcceptor || tileEntity instanceof IStrictEnergyOutputter))
+            if ((!EnergyConfigHandler.disableMekanismOutput || !EnergyConfigHandler.disableMekanismInput) && isMekLoaded && (tileEntity instanceof IStrictEnergyAcceptor || tileEntity instanceof IStrictEnergyOutputter))
             {
                 // Do not connect GC wires directly to Mek Universal Cables
                 try
@@ -143,7 +143,7 @@ public class EnergyUtil
                 continue;
             }
 
-            if (isBCReallyLoaded)
+            if ((!EnergyConfigHandler.disableBuildCraftOutput || !EnergyConfigHandler.disableBuildCraftInput) && isBCReallyLoaded)
             {
                 // Do not connect GC wires directly to BC pipes of any type
                 try
@@ -164,7 +164,7 @@ public class EnergyUtil
                 }
             }
 
-            if (isRFLoaded && tileEntity instanceof IEnergyConnection)
+            if ((!EnergyConfigHandler.disableRFOutput || !EnergyConfigHandler.disableRFInput) && isRFLoaded && tileEntity instanceof IEnergyConnection)
             {
                 if (isRF2Loaded && (tileEntity instanceof IEnergyProvider || tileEntity instanceof IEnergyReceiver) || isRF1Loaded && tileEntity instanceof IEnergyHandler
                     || clazzRailcraftEngine != null && clazzRailcraftEngine.isInstance(tileEntity))
@@ -182,7 +182,7 @@ public class EnergyUtil
                 continue;
             }
 
-            if (isIC2Loaded && !isIC2ClassicLoaded)
+            if ((!EnergyConfigHandler.disableIC2Output || !EnergyConfigHandler.disableIC2Input) && isIC2Loaded && !isIC2ClassicLoaded)
             {
                 if (tileEntity instanceof IEnergyConductor)
                 {
@@ -301,7 +301,7 @@ public class EnergyUtil
      * entered in the Lists more than once, with a different direction each
      * time: this would represent GC wires connected to the acceptor on more
      * than one side.)
-     * 
+     *
      * @param conductor
      * @param connectedAcceptors
      * @param directions
@@ -343,7 +343,7 @@ public class EnergyUtil
                 continue;
             }
 
-            if (isMekLoaded && tileEntity instanceof IStrictEnergyAcceptor)
+            if (!EnergyConfigHandler.disableMekanismOutput && isMekLoaded && tileEntity instanceof IStrictEnergyAcceptor)
             {
                 if (clazzMekCable != null && clazzMekCable.isInstance(tileEntity))
                 {
@@ -357,7 +357,7 @@ public class EnergyUtil
                 continue;
             }
 
-            if (isIC2Loaded && !world.isRemote)
+            if (!EnergyConfigHandler.disableIC2Output && isIC2Loaded && !world.isRemote)
             {
                 IEnergyTile IC2tile = null;
                 BlockPos checkingIC2 = thisVec.toBlockPos().offset(direction);
@@ -384,7 +384,7 @@ public class EnergyUtil
                 }
             }
 
-            if (isBCReallyLoaded)
+            if (!EnergyConfigHandler.disableBuildCraftOutput && isBCReallyLoaded)
             {
                 if (clazzPipeTile != null && clazzPipeTile.isInstance(tileEntity))
                 {
@@ -400,7 +400,7 @@ public class EnergyUtil
                 }
             }
 
-            if ((isRF2Loaded && tileEntity instanceof IEnergyReceiver) || (isRF1Loaded && tileEntity instanceof IEnergyHandler))
+            if (!EnergyConfigHandler.disableRFOutput && (isRF2Loaded && tileEntity instanceof IEnergyReceiver) || (isRF1Loaded && tileEntity instanceof IEnergyHandler))
             {
                 if (clazzMFRRednetEnergyCable != null && clazzMFRRednetEnergyCable.isInstance(tileEntity))
                 {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/energy/EnergyUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/energy/EnergyUtil.java
@@ -667,7 +667,7 @@ public class EnergyUtil
         // Initialise a couple of non-IC2 classes
         try
         {
-            clazzMekCable = Class.forName("codechicken.multipart.TileMultipart");
+            clazzMekCable = Class.forName("mekanism.common.tile.transmitter.TileEntityUniversalCable");
         } catch (Exception e)
         {
         }
@@ -685,7 +685,7 @@ public class EnergyUtil
         }
         try
         {
-            clazzRailcraftEngine = Class.forName("mods.railcraft.common.blocks.machine.beta.TileEngine");
+            clazzRailcraftEngine = Class.forName("mods.railcraft.common.blocks.single.TileEngine");
         } catch (Exception e)
         {
         }

--- a/src/main/java/micdoodle8/mods/galacticraft/core/energy/tile/TileBaseUniversalElectrical.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/energy/tile/TileBaseUniversalElectrical.java
@@ -45,7 +45,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.items.CapabilityItemHandler;
 
 @InterfaceList(value = {
-    @Interface(iface = "ic2.api.energy.tile.IEnergySink", modid = CompatibilityManager.modidIC2), 
+    @Interface(iface = "ic2.api.energy.tile.IEnergySink", modid = CompatibilityManager.modidIC2),
     @Interface(iface = "ic2.api.energy.tile.IEnergyAcceptor", modid = CompatibilityManager.modidIC2),
     @Interface(iface = "buildcraft.api.mj.IMjReceiver", modid = CompatibilityManager.modBCraftEnergy),
     @Interface(iface = "mekanism.api.energy.IStrictEnergyOutputter", modid = CompatibilityManager.modidMekanism),
@@ -479,7 +479,6 @@ public abstract class TileBaseUniversalElectrical extends EnergyStorageTile impl
     }
 
     @Override
-    @Method(modid = CompatibilityManager.modidMekanism)
     public boolean canOutputEnergy(EnumFacing side)
     {
         return this.getElectricalOutputDirections().contains(side);


### PR DESCRIPTION
Since this has led to some confusion in Tekkit 2:
When both energy input and output are disabled via config, energy connections are not needed. This was already done for Forge Energy but was missing for the remaining energy types.