### PR TITLE
fix: fluid in tanks lost after server reload

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityFluidTank.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tile/TileEntityFluidTank.java
@@ -276,7 +276,7 @@ public class TileEntityFluidTank extends TileEntityAdvanced implements IFluidHan
     {
         super.readFromNBT(nbt);
 
-        if (nbt.hasKey("fuelTank"))
+        if (nbt.hasKey("fluidTank"))
         {
             fluidTank.readFromNBT(nbt.getCompoundTag("fluidTank"));
         }


### PR DESCRIPTION
Fixes issue #104. Because of a typo in a conditional statement, the line that reads the nbt was never executed.