### PR TITLE
fix(#130):Wrong slots returned for the sides facing

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntityGasLiquefier.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/planets/mars/tile/TileEntityGasLiquefier.java
@@ -552,17 +552,9 @@ public class TileEntityGasLiquefier extends TileBaseElectricBlockWithInventory i
     @Override
     public int[] getSlotsForFace(EnumFacing side)
     {
-        if (side == EnumFacing.DOWN)
-        {
-            return new int[] {0, 1, 2, 3};
-        }
-
-        if (side == EnumFacing.UP)
-        {
-            return new int[] {0};
-        }
-
-        return new int[] {1, 2, 3};
+       
+       
+        return side == EnumFacing.UP ? new int[] { 0 } : new int[] { 0, 1, 2 };
     }
 
     @Override
@@ -596,7 +588,7 @@ public class TileEntityGasLiquefier extends TileBaseElectricBlockWithInventory i
             case 1:
                 return FluidUtil.isEmptyContainer(itemstack);
             case 2:
-            case 3:
+        
                 return FluidUtil.isFullContainer(itemstack);
 
             default:
@@ -613,7 +605,7 @@ public class TileEntityGasLiquefier extends TileBaseElectricBlockWithInventory i
                 return ItemElectricBase.isElectricItem(itemstack.getItem());
             case 1:
             case 2:
-            case 3:
+            
                 return FluidUtil.isValidContainer(itemstack);
         }
 


### PR DESCRIPTION
Hotfix for #130 , the `getSlotsForFace()`  method wasn't changed in  75f11959adbc11a23aa64b4125a980af0eb5f5fa so it was returning the wrong slots number for the faces of the Gas Liquefier.