### PR TITLE
Improve the mechanism of canned food

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemFood.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/items/ItemFood.java
@@ -169,7 +169,7 @@ public class ItemFood extends net.minecraft.item.ItemFood implements ISortableIt
         worldIn.playSound(null, entityLiving.posX, entityLiving.posY, entityLiving.posZ, SoundEvents.ENTITY_PLAYER_BURP, SoundCategory.PLAYERS, 0.5F, worldIn.rand.nextFloat() * 0.1F + 0.9F);
         if (!worldIn.isRemote && (stack.getItemDamage() < 4 || stack.getItemDamage() == 9))
         {
-            entityLiving.entityDropItem(new ItemStack(GCItems.canister, 1, 0), 0.0F);
+            ItemHandlerHelper.giveItemToPlayer(player, new ItemStack(GCItems.canister, 1, 0), 0);
         }
         stack.shrink(1);
         return stack;


### PR DESCRIPTION
Optimized the mechanism for players to obtain tin cans after consuming canned food, prioritizing their placement in the player's inventory. If the inventory is full, tin cans will fall to the world.
My English is not very good, please forgive me.