### PR TITLE
Fix Javadoc errors.

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/galaxies/GalaxyRegistry.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/galaxies/GalaxyRegistry.java
@@ -95,7 +95,7 @@ public class GalaxyRegistry
     }
 
     /**
-     * Returns the CelestialBody of the given DimensionID. Iterates through, Planets, Moons & Satellites only
+     * Returns the CelestialBody of the given DimensionID. Iterates through, Planets, Moons &amp; Satellites only
      *
      * @param  dimensionID the DIM Id of the CelestialBody
      *
@@ -296,7 +296,8 @@ public class GalaxyRegistry
     // -- DEPRECIATED METHODS -- //
 
     /**
-     * @ReplaceWith {@link GalaxyRegistry#getPlanetOrMoonFromTranslationkey(String translationKey)}
+	 *
+     * Replace with {@link GalaxyRegistry#getPlanetOrMoonFromTranslationkey(String translationKey)}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.getPlanetOrMoonFromTranslationkey(String translationKey)")
@@ -306,7 +307,7 @@ public class GalaxyRegistry
     }
 
     /**
-     * @ReplaceWith {@link GalaxyRegistry#register(T object)}
+     * Replace with {@link GalaxyRegistry#register(Object object)}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.register(T object)")
@@ -317,7 +318,7 @@ public class GalaxyRegistry
     }
 
     /**
-     * @ReplaceWith {@link GalaxyRegistry#register(T object)}
+     * Replace with {@link GalaxyRegistry#register(Object object)}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.register(T object)")
@@ -328,7 +329,7 @@ public class GalaxyRegistry
     }
 
     /**
-     * @ReplaceWith {@link GalaxyRegistry#register(T object)}
+     * Replace with {@link GalaxyRegistry#register(Object object)}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.register(T object)")
@@ -339,7 +340,7 @@ public class GalaxyRegistry
     }
 
     /**
-     * @ReplaceWith {@link GalaxyRegistry#register(T object)}
+     * Replace with {@link GalaxyRegistry#register(Object object)}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.register(T object)")
@@ -351,8 +352,8 @@ public class GalaxyRegistry
 
     /**
      * Returns a read-only map containing Solar System Names and their associated Solar Systems.
-     *
-     * @ReplaceWith {@link GalaxyRegistry#getSolarSystems()}
+     * <p>
+     * Replace with {@link GalaxyRegistry#getSolarSystems()}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.getSolarSystems()")
@@ -363,8 +364,8 @@ public class GalaxyRegistry
 
     /**
      * Returns a read-only map containing Planet Names and their associated Planets.
-     *
-     * @ReplaceWith {@link GalaxyRegistry#getPlanets()}
+     * <p>
+     * Replace with {@link GalaxyRegistry#getPlanets()}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.getPlanets()")
@@ -375,8 +376,8 @@ public class GalaxyRegistry
 
     /**
      * Returns a read-only map containing Moon Names and their associated Moons.
-     *
-     * @ReplaceWith {@link GalaxyRegistry#getMoons()}
+     * <p>
+     * Replace with {@link GalaxyRegistry#getMoons()}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.getMoons()")
@@ -387,8 +388,8 @@ public class GalaxyRegistry
 
     /**
      * Returns a read-only map containing Satellite Names and their associated Satellite.
-     *
-     * @ReplaceWith {@link GalaxyRegistry#getSatellites()}
+     * <p>
+     * Replace with {@link GalaxyRegistry#getSatellites()}
      */
     @Deprecated
     @ReplaceWith("GalaxyRegistry.getSatellites()")

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/CircuitFabricatorRecipes.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/CircuitFabricatorRecipes.java
@@ -23,16 +23,14 @@ public class CircuitFabricatorRecipes
 
     /**
      * Input list must be array with 5 elements matching the 5 slots in the
-     * machine. Use null if no item is used in the slot. Use a List<ItemStack>
-     * for Oredicted ingredients. <p> 0: Diamond 1: Silicon 2: Silicon 3:
-     * Redstone dust 4: Recipe item
+     * machine. Use null if no item is used in the slot. Use a List&lt;net.minecraft.item.ItemStack&gt;
+     * for Oredicted ingredients. <p>0: Diamond 1: Silicon 2: Silicon 3: Redstone dust 4: Recipe item</p>
      *
-     * @param output ItemStack
+     * @param output net.minecraft.item.ItemStack
      * @param inputList Object array. Must contain only null, ItemStack, or
-     *        List<ItemStack>.
-     * 
-     * @return
-     */
+     *        List&lt;ItemStack&gt;.
+     *
+	 */
     public static void addRecipe(ItemStack output, List<Object> inputList)
     {
         if (inputList.size() != 5)
@@ -61,7 +59,7 @@ public class CircuitFabricatorRecipes
 
     /**
      * Add the recipe ingredients to the valid items for each slot
-     * 
+     *
      * @param inputList
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/IRecipeUpdatable.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/IRecipeUpdatable.java
@@ -15,18 +15,18 @@ public interface IRecipeUpdatable extends IRecipe
 {
 
     /**
-     * Replace all inputs which match ItemStack inputA with a List<ItemStack>
+     * Replace all inputs which match ItemStack inputA with a List&lt;ItemStack&gt;
      * (probably representing OreDict output).
-     * 
-     * @param inputA the current simple ItemStack ingredient
-     * @param inputB the List<ItemStack> to replace it with
+     *
+     * @param ingredient the current simple ItemStack ingredient
+     * @param replacement the List&lt;ItemStack&gt; to replace it with
      */
     public void replaceInput(ItemStack ingredient, List<ItemStack> replacement);
 
     /**
      * Replace all inputs which are lists containing ItemStack ingredient with
      * simple ItemStack of ingredient.
-     * 
+     *
      * @param ingredient
      */
     public void replaceInput(ItemStack ingredient);

--- a/src/main/java/micdoodle8/mods/galacticraft/api/recipe/SchematicRegistry.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/recipe/SchematicRegistry.java
@@ -121,7 +121,6 @@ public class SchematicRegistry
      *
      * @param currentIndex the current index of unlocked schematics the player
      *        is viewing
-     * @return the schematic page that will be shown when the player clicks NEXT
      */
     @SideOnly(Side.CLIENT)
     public static void flipToNextPage(GuiScreen cs, int currentIndex)
@@ -138,7 +137,6 @@ public class SchematicRegistry
      *
      * @param currentIndex the current index of unlocked schematics the player
      *        is viewing
-     * @return the schematic page that will be shown when the player clicks BACK
      */
     @SideOnly(Side.CLIENT)
     public static void flipToLastPage(GuiScreen cs, int currentIndex)

--- a/src/main/java/micdoodle8/mods/galacticraft/api/world/IGalacticraftWorldProvider.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/world/IGalacticraftWorldProvider.java
@@ -26,7 +26,7 @@ public interface IGalacticraftWorldProvider
 
     /**
      * Gets custom arrow gravity, overriding the vanilla gravity for arrows
-     * 
+     *
      * @return added y-motion per tick for arrows
      */
     float getArrowGravity();
@@ -66,7 +66,7 @@ public interface IGalacticraftWorldProvider
     float getFallDamageModifier();
 
     /**
-     * 
+     *
      * @return true if this world has no type of atmosphere at all - e.g. the
      *         Moon
      */
@@ -94,7 +94,7 @@ public interface IGalacticraftWorldProvider
      * If false (the default) then Nether Portals will have no function on this
      * world. Nether Portals can still be constructed, if the player can make
      * fire, they just won't do anything.
-     * 
+     *
      * @return True if Nether Portals should work like on the Overworld.
      */
     boolean netherPortalsOperational();
@@ -125,9 +125,9 @@ public interface IGalacticraftWorldProvider
     float getWindLevel();
 
     /**
-     * Factor by which the sun is to be drawn smaller (<1.0) or larger (>1.0)
+     * Factor by which the sun is to be drawn smaller (&lt;1.0) or larger (&gt;1.0)
      * than the sun on the Overworld
-     * 
+     *
      * @return factor
      */
     float getSolarSize();

--- a/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCEntityPlayerMP.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/entities/player/GCEntityPlayerMP.java
@@ -19,7 +19,7 @@ import net.minecraft.world.WorldServer;
 
 /**
  * This class provides various hooks which are missing from Forge or don't quite
- * do what we need. </p> Do not reference this or test 'instance of' this in
+ * do what we need. <p> Do not reference this or test 'instance of' this in
  * your code: if PlayerAPI is installed, GCEntityPlayerMP will not be used.
  */
 public class GCEntityPlayerMP extends EntityPlayerMP

--- a/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerServer.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/tick/TickHandlerServer.java
@@ -186,7 +186,7 @@ public class TickHandlerServer
      * Only use this for AIR blocks (any type of BlockAir)
      *
      * @param dimID
-     * @param changeAdd List of <ScheduledBlockChange>
+     * @param changeAdd List of {@link micdoodle8.mods.galacticraft.core.wrappers.ScheduledBlockChange}
      */
     public static void scheduleNewBlockChange(int dimID, List<ScheduledBlockChange> changeAdd)
     {

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/ASMUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/ASMUtil.java
@@ -160,7 +160,7 @@ public class ASMUtil {
      * Returns the value of a private static field for a class.
      *
      * @param clazz      The class for which the field value is to be extracted.
-     * @param fieldNames A list of field names for which the value should be extracted.
+     * @param fieldName A list of field names for which the value should be extracted.
      * @return The value of the provided field name.
      */
     @SuppressWarnings("unchecked")
@@ -181,7 +181,7 @@ public class ASMUtil {
      * @param  clazz          The class to find the method on.
      * @param  methodName     The name of the method to find (used in developer environments, i.e. "getWorldTime").
      * @param  parameterTypes The parameter types of the method to find.
-     * 
+     *
      * @return                The method with the specified name and parameters in the given class.
      */
     @Nonnull
@@ -207,7 +207,7 @@ public class ASMUtil {
      * @param  methodName     The name of the method to find (used in developer environments, i.e. "getWorldTime").
      * @param  methodObfName  The obfuscated name of the method to find (used in obfuscated environments, i.e. "getWorldTime"). If the name you are looking for is on a class that is never obfuscated, this should be null.
      * @param  parameterTypes The parameter types of the method to find.
-     * 
+     *
      * @return                The method with the specified name and parameters in the given class.
      */
     @Nonnull

--- a/src/main/java/micdoodle8/mods/galacticraft/core/util/I18nUtil.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/core/util/I18nUtil.java
@@ -72,7 +72,7 @@ public final class I18nUtil
 
     /**
      * Translates the text with key "(prefix).registry_name.key". This uses the object's registry
-     * name namespace instead of {@link #modId}. Prefix is determined by the object's type.
+     * name namespace instead of modId. Prefix is determined by the object's type.
      *
      * @param object An {@link IForgeRegistryEntry} of some kind, such as a {@link Block} or {@link
      *               Item}


### PR DESCRIPTION
As it is currently written, the Javadocs for Galacticraft have incorrect format and thus do not build when you do the `:javadoc` gradle task. This pull requests modifies these Javadocs so as to fix these errors.