### PR TITLE
Update magnetic_table.json

### DIFF
--- a/src/main/resources/assets/galacticraftcore/recipes/magnetic_table.json
+++ b/src/main/resources/assets/galacticraftcore/recipes/magnetic_table.json
@@ -4,7 +4,8 @@
   },
   "ingredients": [
     {
-      "item": "minecraft:crafting_table"
+      "type": "forge:ore_dict",
+      "ore": "workbench"
     },
     {
       "type": "forge:ore_dict",


### PR DESCRIPTION
Changed the Magnetic Crafting Table to accept the "workbench" ore dictionary instead of just the vanilla crafting table so the recipe can be crafted with any modded crafting table.